### PR TITLE
Error message create/merge relationship

### DIFF
--- a/py2neo/internal/operations.py
+++ b/py2neo/internal/operations.py
@@ -130,23 +130,26 @@ def create_subgraph(tx, subgraph):
     :param subgraph:
     :return:
     """
-    graph = tx.graph
-    for labels, nodes in _node_create_dict(n for n in subgraph.nodes if n.graph is None).items():
-        identities = _create_nodes(tx, labels, list(map(dict, nodes)))
-        for i, identity in enumerate(identities):
-            node = nodes[i]
-            node.graph = graph
-            node.identity = identity
-            node._remote_labels = labels
-            graph.node_cache.update(identity, node)
-    for r_type, relationships in _rel_create_dict(r for r in subgraph.relationships if r.graph is None).items():
-        identities = _merge_relationships(tx, r_type, list(map(
-            lambda r: [r.start_node.identity, r.end_node.identity, dict(r)], relationships)))
-        for i, identity in enumerate(identities):
-            relationship = relationships[i]
-            relationship.graph = graph
-            relationship.identity = identity
-            graph.relationship_cache.update(identity, relationship)
+    try:
+        graph = tx.graph
+        for labels, nodes in _node_create_dict(n for n in subgraph.nodes if n.graph is None).items():
+            identities = _create_nodes(tx, labels, list(map(dict, nodes)))
+            for i, identity in enumerate(identities):
+                node = nodes[i]
+                node.graph = graph
+                node.identity = identity
+                node._remote_labels = labels
+                graph.node_cache.update(identity, node)
+        for r_type, relationships in _rel_create_dict(r for r in subgraph.relationships if r.graph is None).items():
+            identities = _merge_relationships(tx, r_type, list(map(
+                lambda r: [r.start_node.identity, r.end_node.identity, dict(r)], relationships)))
+            for i, identity in enumerate(identities):
+                relationship = relationships[i]
+                relationship.graph = graph
+                relationship.identity = identity
+                graph.relationship_cache.update(identity, relationship)
+    except AttributeError as err:
+        raise AttributeError("Invalid node merge, you probably passed None or an invalid Node type")
 
 
 def merge_subgraph(tx, subgraph, p_label, p_key):
@@ -159,25 +162,29 @@ def merge_subgraph(tx, subgraph, p_label, p_key):
     :param p_key:
     :return:
     """
-    graph = tx.graph
-    for (pl, pk, labels), nodes in _node_merge_dict(p_label, p_key, (n for n in subgraph.nodes if n.graph is None)).items():
-        if pl is None or pk is None:
-            raise ValueError("Primary label and primary key are required for MERGE operation")
-        identities = _merge_nodes(tx, pl, pk, labels, list(map(lambda n: [n.get(pk), dict(n)], nodes)))
-        for i, identity in enumerate(identities):
-            node = nodes[i]
-            node.graph = graph
-            node.identity = identity
-            node._remote_labels = labels
-            graph.node_cache.update(identity, node)
-    for r_type, relationships in _rel_create_dict(r for r in subgraph.relationships if r.graph is None).items():
-        identities = _merge_relationships(tx, r_type, list(map(
-            lambda r: [r.start_node.identity, r.end_node.identity, dict(r)], relationships)))
-        for i, identity in enumerate(identities):
-            relationship = relationships[i]
-            relationship.graph = graph
-            relationship.identity = identity
-            graph.relationship_cache.update(identity, relationship)
+    try:
+        graph = tx.graph
+        for (pl, pk, labels), nodes in _node_merge_dict(p_label, p_key, (n for n in subgraph.nodes if n.graph is None)).items():
+            if pl is None or pk is None:
+                raise ValueError("Primary label and primary key are required for MERGE operation")
+            identities = _merge_nodes(tx, pl, pk, labels, list(map(lambda n: [n.get(pk), dict(n)], nodes)))
+            for i, identity in enumerate(identities):
+                node = nodes[i]
+                node.graph = graph
+                node.identity = identity
+                node._remote_labels = labels
+                graph.node_cache.update(identity, node)
+        for r_type, relationships in _rel_create_dict(r for r in subgraph.relationships if r.graph is None).items():
+            identities = _merge_relationships(tx, r_type, list(map(
+                lambda r: [r.start_node.identity, r.end_node.identity, dict(r)], relationships)))
+            for i, identity in enumerate(identities):
+                relationship = relationships[i]
+                relationship.graph = graph
+                relationship.identity = identity
+                graph.relationship_cache.update(identity, relationship)
+    except AttributeError as err:
+        raise AttributeError("Invalid node merge, you probably passed None or an invalid Node")
+
 
 
 def delete_subgraph(tx, subgraph):


### PR DESCRIPTION
Add error message when trying to create or merge a relationship with invalid or None type.

I spent one hour trying to understand what was going wrong until I realized I was trying to index a None type from my database. Adding a simple error handler should improve productivity!